### PR TITLE
Anyio3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A Redis client for Python supporting many Redis features and Python synchronous 
 
 - Transparent API (Just call the Redis commands, and the library will figure out cluster routing, script caching, etc...)
 - Per context and command properties (database #, decoding, RESP3 attributes)
-- Asynchronous I/O support with the same exact API (but with the await keyword), targeting asyncio, trio and curio (using [AnyIO](https://github.com/agronholm/anyio) which needs to be installed as well if you want async I/O)
+- Asynchronous I/O support with the same exact API (but with the await keyword), targeting asyncio and trio (using [AnyIO](https://github.com/agronholm/anyio) which needs to be installed as well if you want async I/O)
 - Modular API allowing for easy support for multiple synchronous and asynchronous event loops and disabling of unneeded features
 - CI Testing for CPython 3.5, 3.6, 3.7, 3.8, 3.9 and PyPy3 with Redis 5 and Redis 6
 - No legacy support for old language features

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = justredis
-version = 0.0.1a3
+version = 0.0.1a4
 description = A Redis client for Python supporting many Redis features and Python synchronous (Python 3.5+) and asynchronous (Python 3.6+) communication.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/async/test_async.py
+++ b/tests/async/test_async.py
@@ -247,10 +247,10 @@ async def test_cancel(client):
     r = client
 
     async with anyio.create_task_group() as tg:
-        await tg.spawn(r, "blpop", "a", 20)
+        tg.start_soon(r, "blpop", "a", 20)
         await anyio.sleep(1)
-        await tg.cancel_scope.cancel()
+        tg.cancel_scope.cancel()
 
     await anyio.sleep(1)
     async with anyio.create_task_group() as tg:
-        await tg.spawn(r, "blpop", "a", 1)
+        tg.start_soon(r, "blpop", "a", 1)

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skip_missing_interpreters = true
 deps =
   pytest
   pytest-cov
-  py{36,37,38,39,py3}: anyio[trio,curio]
+  py{36,37,38,39,py3}: anyio[trio]
 commands =
   py{35,36,37,38,39,py3}: pytest --cov={toxinidir}/justredis --cov={toxinidir}/tests --cov-append --cov-report=term-missing {posargs}
 passenv =


### PR DESCRIPTION
This pull request changes the usage of anyio to use the anyio 3.x API interface instead of anyio 2.x and bumps the version to 0.0.1a4. Also reflects the fact that curio support was removed from anyio.